### PR TITLE
ERR (3): Notice: Undefined variable: storeId

### DIFF
--- a/app/code/community/Ralab/Smtp/Helper/Data.php
+++ b/app/code/community/Ralab/Smtp/Helper/Data.php
@@ -39,7 +39,7 @@ class Ralab_Smtp_Helper_Data extends Mage_Core_Helper_Abstract
         return Mage::getStoreConfig('system/smtp/smtp_ssl', $storeId);
     }
 
-    public function getTransport () {
+    public function getTransport ($storeId = null) {
 
         $config = array();
 


### PR DESCRIPTION
The method getTransport returns an error of undefined variable related to storeid, added it as argument as it is done in other methods